### PR TITLE
Fix model.sdf formatting by closing link tag

### DIFF
--- a/models/green_ball/model.sdf
+++ b/models/green_ball/model.sdf
@@ -23,6 +23,7 @@
             </script>
           </material>
         </visual>
+      </link>
     </model>
 </sdf>
 


### PR DESCRIPTION
### Fix: Missing `</link>` tag in green_ball model

This PR adds the missing closing `</link>` tag in `models/green_ball/model.sdf` which was causing an SDF parsing issue.

Fixes #2